### PR TITLE
Access-control-allow-origin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,10 @@ services:
       - "logging=true"
     logging: *default-logging
   identifier:
-    image: semtech/mu-identifier:1.5.0
+  identifier:
+    image: semtech/mu-identifier:1.6.1
+    environment:
+      DEFAULT_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER: "*"
     restart: always
     labels:
       - "logging=true"


### PR DESCRIPTION
By setting the access-control-allow-origin header to *, we allow to fetch these contents from any remote website.  This will help integrate our technology into other applications and make them more widespread.

This could help integration by vendors and allows us to better answer their requests.