### PR TITLE
[DL-6037] `fastboot-app-server` config changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ x-logging:
 
 services:
   mandaten:
-    image: lblod/frontend-mandatendatabank:0.13.4
+    image: lblod/frontend-mandatendatabank:0.14.0
     links:
       - identifier:backend
     restart: always
@@ -26,7 +26,7 @@ services:
       - "logging=true"
     logging: *default-logging
   dispatcher:
-    image: semtech/mu-dispatcher:1.1.2
+    image: semtech/mu-dispatcher:2.1.0-beta.2
     volumes:
       - ./config/dispatcher:/config
     restart: always


### PR DESCRIPTION
Changes to the setup to make the [new fastboot frontend](https://github.com/lblod/frontend-mandatendatabank/pull/32) (based on `fastboot-app-server`) work.

The implementation is based on the documentation of the [fastboot-app-server docs](https://github.com/redpencilio/fastboot-app-server-service?tab=readme-ov-file#wire-this-image-in-a-semanticworks-project) and [app-centrale-vindplaats](https://github.com/lblod/app-centrale-vindplaats/blob/master/config/dispatcher/dispatcher.ex) which also uses this setup.

#### Current status
Deployed on the dev environment for easy testing, and the frontend seems to be working as expected. I moved the letsencrypt env variables and network config from the `mandaten` service to the `identifier` in the overrides file. This would need to happen on every environment on deploy.

I don't know enough about any of the background systems to know if those are still working as expected after the dispatcher change.

#### Todo

- Add some deploy instructions to the changelog since it requires changes in the overrides files of all environments.
