### PR TITLE
Add mandataris status codes to op consumer

### DIFF
--- a/config/op-consumer/mapping/queries/op2dl/pass/bestuurseenheid-classificatie-code.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/pass/bestuurseenheid-classificatie-code.sparql
@@ -1,11 +1,6 @@
-PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-PREFIX dct: <http://purl.org/dc/terms/>
-PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
-PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-
 CONSTRUCT {
-  ?s ?p ?o.
+  ?s a <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode> ;
+    ?p ?o.
 } WHERE {
   ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode>;
     ?p ?o.

--- a/config/op-consumer/mapping/queries/op2dl/pass/bestuursorgaan-classificatie-code.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/pass/bestuursorgaan-classificatie-code.sparql
@@ -1,13 +1,6 @@
-
-
-PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-PREFIX dct: <http://purl.org/dc/terms/>
-PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
-PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-
 CONSTRUCT {
-  ?s ?p ?o.
+  ?s a <http://mu.semte.ch/vocabularies/ext/BestuursorgaanClassificatieCode> ;
+    ?p ?o.
 } WHERE {
   ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuursorgaanClassificatieCode>;
     ?p ?o.

--- a/config/op-consumer/mapping/queries/op2dl/pass/mandataris-status-code.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/pass/mandataris-status-code.sparql
@@ -1,5 +1,6 @@
 CONSTRUCT {
-  ?s ?p ?o.
+  ?s a <http://mu.semte.ch/vocabularies/ext/MandatarisStatusCode> ;
+    ?p ?o.
 } WHERE {
   ?s a <http://lblod.data.gift/vocabularies/organisatie/MandatarisStatusCode>;
     ?p ?o.

--- a/config/op-consumer/mapping/queries/op2dl/pass/mandataris-status-code.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/pass/mandataris-status-code.sparql
@@ -1,0 +1,6 @@
+CONSTRUCT {
+  ?s ?p ?o.
+} WHERE {
+  ?s a <http://lblod.data.gift/vocabularies/organisatie/MandatarisStatusCode>;
+    ?p ?o.
+}


### PR DESCRIPTION
Adds `MandatarisStatusCode` to the types that are allowed to pass by the consumer.

Those values were already flushed by the existing flushing migration, but went un-noticed because in MDB the type used was `http://mu.semte.ch/vocabularies/ext/MandatarisStatusCode` and not `<http://lblod.data.gift/vocabularies/organisatie/MandatarisStatusCode>`. As those values are not any different right now in OP vs in MDB, I suggest we don't add an extra migration to clear them out entirely.

**NOTE:** when deploying this PR to dev, we should manually trigger another initial sync to let the `MandatarisStatusCode` flow through with all the triples defined in OP.