### PR TITLE
Upgrade `virtuoso` to `v1.3.0-rc.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 ## Unreleased
 - Change database from mu-auth to sparql-parser [DL-6562]
+- Bump virtuoso (required for the sparql-parser)
+
 ### Deploy notes
+#### For upgrading virtuoso
+[This README](https://github.com/Riadabd/upgrade-virtuoso) provides the necessary steps for upgrading the database. **NOTE**: This will involve shutting down the app for small period of time (around 30 minutes).
+#### For the database
 ```
 drc up -d database
 ```

--- a/config/virtuoso/virtuoso-production.ini
+++ b/config/virtuoso/virtuoso-production.ini
@@ -28,7 +28,7 @@ TransactionFile    = /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso
 xa_persistent_file = /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.pxa
 ErrorLogLevel      = 7
 FileExtend         = 200
-MaxCheckpointRemap = 170000 ;;niels 1/4 of the number of buffers (assuming db uses most of the available buffers, you can check with `status()` in isql-v
+MaxCheckpointRemap = 17000 ;;niels 1/4 of the number of buffers (assuming db uses most of the available buffers, you can check with `status()` in isql-v
 Striping           = 0
 TempStorage        = TempDatabase
 Syslog             = 1	; write to syslog in case of failures where writing to log is not possible
@@ -92,8 +92,8 @@ TransactionAfterImageLimit = 150000000	; max 150MB transaction, total transient 
 ;;MaxDirtyBuffers            = 130000
 
 ;; Uncomment next two lines if there is 4 GB system memory free
-;NumberOfBuffers          = 340000
-;MaxDirtyBuffers          = 250000
+;;NumberOfBuffers          = 340000
+;;MaxDirtyBuffers          = 250000
 ;; Uncomment next two lines if there is 8 GB system memory free
 NumberOfBuffers          = 680000
 MaxDirtyBuffers          = 500000
@@ -231,10 +231,12 @@ DefaultHost  = localhost:8890
 ;DefaultGraph           = http://localhost:8890/dataspace
 ;ImmutableGraphs        = http://localhost:8890/dataspace
 ResultSetMaxRows           = 1000000 ; 1 million
+MaxConstructTriples        = 10000 ; More info on this addition here: https://github.com/redpencilio/docker-virtuoso/pull/29
 ;MaxQueryCostEstimationTime = 4000	; in seconds
 MaxQueryExecutionTime      = 1200	; in seconds
 DefaultQuery               = select distinct ?Concept where {[] a ?Concept} LIMIT 100
 DeferInferenceRulesInit    = 0	; controls inference rules loading
+MaxMemInUse                = 0 ; limits the amount of memory for construct dict (0=unlimited). More info on this addition here: https://github.com/redpencilio/docker-virtuoso/pull/29
 ;PingService            = http://rpc.pingthesemanticweb.com/
 
 [Plugins]

--- a/config/virtuoso/virtuoso.ini
+++ b/config/virtuoso/virtuoso.ini
@@ -231,10 +231,12 @@ DefaultHost  = localhost:8890
 ;DefaultGraph           = http://localhost:8890/dataspace
 ;ImmutableGraphs        = http://localhost:8890/dataspace
 ResultSetMaxRows           = 1000000 ; 1 million
+MaxConstructTriples        = 10000 ; More info on this addition here: https://github.com/redpencilio/docker-virtuoso/pull/29
 ;MaxQueryCostEstimationTime = 4000	; in seconds
 MaxQueryExecutionTime      = 1200	; in seconds
 DefaultQuery               = select distinct ?Concept where {[] a ?Concept} LIMIT 100
 DeferInferenceRulesInit    = 0	; controls inference rules loading
+MaxMemInUse                = 0 ; limits the amount of memory for construct dict (0=unlimited). More info on this addition here: https://github.com/redpencilio/docker-virtuoso/pull/29
 ;PingService            = http://rpc.pingthesemanticweb.com/
 
 [Plugins]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     restart: always
     logging: *default-logging
   virtuoso:
-    image: tenforce/virtuoso:1.3.2-virtuoso7.2.1
+    image: redpencil/virtuoso:1.3.0-rc.1
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"


### PR DESCRIPTION
# Context

[DL-6562]

The old virtuoso version used here is conflicting with the sparql-parser introduced in #17 . It causes the consumers to only be able to do `SELECT` queries but no `INSERT` or `DELETE` which is a bit annoying for consumers.

I based myself on https://github.com/lblod/app-organization-portal/pull/522 and https://github.com/Riadabd/upgrade-virtuoso to upgrade virtuoso here as well.